### PR TITLE
Init umami-infra con soporte multi-pila y paquete cfg

### DIFF
--- a/desployments/cdk/umami-cloud-go.go
+++ b/desployments/cdk/umami-cloud-go.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"umami-cloud-go/pkg/cfg" // Importación corregida usando tu nombre de módulo
+	"umami-cloud-go/pkg/cfg"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsec2"


### PR DESCRIPTION
Technical Tasks Performed:

- [x] Module initialization: The commands go mod init umami-cloud-go and cdk init app --language go were executed within the deployment directory.

- [x]  Package structure: A package named cfg was created under pkg/cfg for configuration management, deliberately avoiding redundant or overly verbose naming.

- [x]  Multi-stack support: The main file dynamically generates the UmamiStackDev and UmamiStackProd stacks using a shared common structure, adhering to the DRY (Don't Repeat Yourself) principle to eliminate code duplication.

- [x] Effective Go practices: The MixedCaps naming convention (CamelCase) was consistently applied to all exported functions and types, removing underscores from identifiers in accordance with standard Go naming style.