### PR TITLE
feat: deploy umami via docker-compose (Resolves UCG-6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# Local environment files
+.env

--- a/cdk/compute.go
+++ b/cdk/compute.go
@@ -58,5 +58,13 @@ chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 	})
 
 	awscdk.Tags_Of(server).Add(jsii.String("Environment"), jsii.String(props.EnvValue), &awscdk.TagProps{})
+
+	server.Connections().AllowFromAnyIpv4(
+		awsec2.Port_Tcp(jsii.Number(3000)),
+		jsii.String("Allow inbound traffic for Umami on port 3000"),
+	)
+
+	awscdk.Tags_Of(server).Add(jsii.String("Environment"), jsii.String(props.EnvValue), &awscdk.TagProps{})
+
 	return server
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      DATABASE_TYPE: postgresql
+      APP_SECRET: ${APP_SECRET}
+    restart: always
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - umami-db-data:/var/lib/postgresql/data
+    restart: always
+
+volumes:
+  umami-db-data:


### PR DESCRIPTION
This PR introduces the docker-compose setup for Umami and Postgres, and opens TCP port 3000 in the Dev environment Security Group.